### PR TITLE
use cryptography module

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ context = aia_session.ssl_context_from_url(url)
 response = urlopen(url, context=context)
 ```
 
+To cache the downloaded intermediary certificates on disk:
+
+```py
+aia_session = AIASession(cache_dir="/tmp/aia-certs")
+```
+
 The context methods also helps when working with HTTP client libraries.
 For example, with [`requests`](http://python-requests.org/):
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ of each certificate,
 and gets the root certificate locally, from the system.
 
 **How does it validate the certificate chain?**
-Through OpenSSL, which must be installed as an external dependency.
+Through OpenSSL, via the [cryptography](https://github.com/pyca/cryptography) module.
 
 **When should I use it?**
 Ideally, never, but that might not be an option.
@@ -30,8 +30,6 @@ or get the intermediary certificates in the chain through AIA
 
 
 ## How to install
-
-Anywhere, assuming OpenSSL is already installed:
 
 ```bash
 pip install aia
@@ -94,7 +92,7 @@ context = aia_session.ssl_context_from_url(url)
 resp = httpx.get(url, verify=context)
 ```
 
-The certificate fetching part of this library and the OpenSSL call
+The certificate fetching and validating part of this library
 are blocking, so this library is still not prepared
 for asynchronous code.
 But one can easily make some workaround to use it, for example with

--- a/aia.py
+++ b/aia.py
@@ -109,11 +109,14 @@ class AIASession:
     @CachedMethod
     def get_host_cert(self, host):
         """
-        Get the DER (binary) certificate for the taget host
+        Get the DER (binary) certificate for the target host
         without checking it (leaf certificate).
         """
         logger.debug(f"Downloading {host} certificate (TLS)")
-        with socket.create_connection((host, 443)) as sock:
+        port = 443
+        if ':' in host:
+            host, port = host.split(':')
+        with socket.create_connection((host, port)) as sock:
             with self._context.wrap_socket(sock, server_hostname=host) as ss:
                 return ss.getpeercert(True)
 

--- a/aia.py
+++ b/aia.py
@@ -223,13 +223,23 @@ class AIASession:
         as joined PEM (ASCII string in base64 with extra delimiters)
         certificates in a single string, to be used in a SSLContext.
         """
+        cadata, host_regex = self.cadata_and_host_regex_from_host(host)
+        return cadata
 
+    def cadata_and_host_regex_from_host(self, host):
+        """
+        Get the certification chain and the host regex.
+        Note: The host regex only matches lowercase hostnames.
+        The host regex also matches ports like example.com:12345.
+        See also cadata_from_host
+        """
         host = host.lower()
 
         for host_regex in self._cadata_from_host_regex:
             if host_regex.fullmatch(host):
                 # read cache
-                return self._cadata_from_host_regex[host_regex]
+                cadata = self._cadata_from_host_regex[host_regex]
+                return cadata, host_regex
 
         der_certs = list(self.aia_chase(host))
 
@@ -258,7 +268,7 @@ class AIASession:
         # write cache
         self._cadata_from_host_regex[host_regex] = cadata
 
-        return cadata
+        return cadata, host_regex
 
     def cadata_from_url(self, url):
         """Façade to the ``cadata_from_host`` method."""

--- a/aia.py
+++ b/aia.py
@@ -6,7 +6,6 @@ import socket
 import ssl
 import select
 import time
-from tempfile import NamedTemporaryFile
 from urllib.request import urlopen, Request
 from urllib.parse import urlsplit
 
@@ -348,7 +347,9 @@ class AIASession:
         # try to load PKCS7-DER format
         try:
             certs = pkcs7.load_der_pkcs7_certificates(cert_bytes)
-            assert len(certs) == 1  # TODO
+            # FIXME Use of assert detected. The enclosed code will be removed
+            #   when compiling to optimised byte code.
+            # assert len(certs) == 1  # TODO
             cert = certs[0]
             # here we need pyopenssl cert
             # for OpenSSL.crypto.X509StoreContext
@@ -437,7 +438,9 @@ class AIASession:
             # convert cert from cryptography to pyopenssl
             # for OpenSSL.crypto.X509StoreContext
             cert = OpenSSL.crypto.X509.from_cryptography(cert)
-        assert isinstance(cert, OpenSSL.crypto.X509)
+        # FIXME Use of assert detected. The enclosed code will be removed
+        #   when compiling to optimised byte code.
+        # assert isinstance(cert, OpenSSL.crypto.X509)
         try:
             ext_bc = cert.to_cryptography().extensions.get_extension_for_class(
                 x509.BasicConstraints
@@ -529,7 +532,7 @@ class AIASession:
         if verify_depth == -1:
             verify_depth = 1000
 
-        for verify_chain_idx in range(verify_depth):
+        for _verify_chain_idx in range(verify_depth):
 
             # logger.debug("verify_chain_idx", verify_chain_idx)
 
@@ -645,7 +648,7 @@ class AIASession:
         print("cadata_and_host_regex_from_host cache miss")
 
         # note: this can throw
-        cert_chain, missing_certs = self.aia_chase(host, timeout)
+        cert_chain, _missing_certs = self.aia_chase(host, timeout)
 
         target_cert = cert_chain[0]
 

--- a/aia.py
+++ b/aia.py
@@ -219,8 +219,10 @@ class AIASession:
                         conn.setblocking(1)
                         raise TimeoutError
                     # TODO? handle timeout from select
-                    readable, writable, errored = select.select([sock], [sock], [], remain)
-                    time.sleep(0.5) # reduce cpu load
+                    readable, writable, errored = select.select(
+                        [sock], [sock], [], remain
+                    )
+                    time.sleep(0.5)  # reduce cpu load
 
         do_handshake()
 
@@ -229,10 +231,6 @@ class AIASession:
         full_cert_chain = conn.get_peer_cert_chain()
         verified_cert_chain = conn.get_verified_chain()
 
-        # FIXME verified_cert_chain can be None
-        # FIXME full_cert_chain can be None
-        print("full_cert_chain"); print_chain(full_cert_chain)
-        print("verified_cert_chain"); print_chain(verified_cert_chain)
         if len(verified_cert_chain) == len(full_cert_chain):
             # rest_cert_chain is empty
             # this does not mean that the chain is valid

--- a/aia.py
+++ b/aia.py
@@ -171,18 +171,16 @@ class AIASession:
         logger.debug("creating AIASession")
         self.user_agent = user_agent
         self.cafile = cafile
-        if cafile:
-            if not os.path.exists(cafile):
-                raise FileNotFoundError(cafile)
-        else:
+        if not cafile:
             import certifi
 
-            self.cafile = cafile = certifi.where()
+            self.cafile = certifi.where()
         self.cache_db = cache_db
         self.cache_db_con = None
         self.cache_db_cur = None
         self.cache_dir = cache_dir
         self._context = OpenSSL.SSL.Context(method=OpenSSL.SSL.TLS_CLIENT_METHOD)
+        # this throws OpenSSL.SSL.Error if cafile is missing or empty
         self._context.load_verify_locations(cafile=self.cafile)
         self._cadata_from_host_regex = dict()
         self._trusted_root_certs = list()

--- a/aia.py
+++ b/aia.py
@@ -347,9 +347,7 @@ class AIASession:
         # try to load PKCS7-DER format
         try:
             certs = pkcs7.load_der_pkcs7_certificates(cert_bytes)
-            # FIXME Use of assert detected. The enclosed code will be removed
-            #   when compiling to optimised byte code.
-            # assert len(certs) == 1  # TODO
+            assert len(certs) == 1  # TODO
             cert = certs[0]
             # here we need pyopenssl cert
             # for OpenSSL.crypto.X509StoreContext
@@ -438,9 +436,7 @@ class AIASession:
             # convert cert from cryptography to pyopenssl
             # for OpenSSL.crypto.X509StoreContext
             cert = OpenSSL.crypto.X509.from_cryptography(cert)
-        # FIXME Use of assert detected. The enclosed code will be removed
-        #   when compiling to optimised byte code.
-        # assert isinstance(cert, OpenSSL.crypto.X509)
+        assert isinstance(cert, OpenSSL.crypto.X509)
         try:
             ext_bc = cert.to_cryptography().extensions.get_extension_for_class(
                 x509.BasicConstraints

--- a/aia.py
+++ b/aia.py
@@ -425,7 +425,7 @@ class AIASession:
         len1 = len(self._trusted_root_certs)
         self._trusted_root_certs = list(filter(
             lambda c: c.digest("sha256") != cert_digest,
-            self._trusted_root_certs.append
+            self._trusted_root_certs
         ))
         len2 = len(self._trusted_root_certs)
         return len1 != len2 # return True if cert was removed

--- a/aia.py
+++ b/aia.py
@@ -170,20 +170,38 @@ class AIASession:
         """
         logger.debug("creating AIASession")
         self.user_agent = user_agent
-        self.cafile = cafile
-        if cafile:
-            if not os.path.exists(cafile):
-                raise FileNotFoundError(cafile)
-        else:
-            import certifi
-
-            self.cafile = cafile = certifi.where()
         self.cache_db = cache_db
         self.cache_db_con = None
         self.cache_db_cur = None
         self.cache_dir = cache_dir
         self._context = OpenSSL.SSL.Context(method=OpenSSL.SSL.TLS_CLIENT_METHOD)
-        self._context.load_verify_locations(cafile=self.cafile)
+        self.cafile = None
+        if cafile:
+            cafile_list = cafile if isinstance(cafile, list) else [cafile]
+        else:
+            import certifi
+
+            cafile_list = [certifi.where()]
+        for cafile in cafile_list:
+            if not os.path.exists(cafile):
+                logger.debug(f"cafile is missing: {cafile}")
+                continue
+            if os.path.getsize(cafile) == 0:
+                logger.debug(f"cafile is empty: {cafile}")
+                continue
+            try:
+                self._context.load_verify_locations(cafile)
+                logger.debug(f"loaded cafile {cafile}")
+                self.cafile = cafile
+                break
+            except OpenSSL.SSL.Error as exc:
+                logger.debug(f"failed to load cafile {cafile}: {exc}")
+        if self.cafile is None:
+            import certifi
+
+            self.cafile = certifi.where()
+            logger.debug(f"failed to load cafile. using default cafile {self.cafile}")
+            self._context.load_verify_locations(self.cafile)
         self._cadata_from_host_regex = dict()
         self._trusted_root_certs = list()
 

--- a/aia.py
+++ b/aia.py
@@ -339,8 +339,7 @@ class AIASession:
         #    raise
 
         # try to load PKCS7 format
-        # https://source.chromium.org/chromium/chromium/src/
-        #   net/cert/internal/cert_issuer_source_aia.cc
+        # https://chromium.googlesource.com/chromium/src/+/refs/heads/main/net/cert/internal/cert_issuer_source_aia.cc
         # https://cryptography.io/ # pkcs7
         # ParseCertsFromCms
 
@@ -418,8 +417,7 @@ class AIASession:
             cert_bytes = resp.read()
             # cert_bytes can have different formats: DER = ASN1, CMS = PKCS7 = P7B, PEM
             # https://tools.ietf.org/html/rfc5280#page-50
-            # https://source.chromium.org/chromium/chromium/src/
-            #   net/cert/internal/cert_issuer_source_aia.cc
+            # https://chromium.googlesource.com/chromium/src/+/refs/heads/main/net/cert/internal/cert_issuer_source_aia.cc
             # AiaRequest::AddCompletedFetchToResults
             cert = self._load_cert_from_bytes(cert_bytes)
             self._write_cert_cache(url_parsed, cert)

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setuptools.setup(
     include_package_data=True,
     python_requires=">=3.6",
     install_requires=[
+        "pyopenssl",
         "cryptography",
         "certifi",
     ],
@@ -43,7 +44,7 @@ setuptools.setup(
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: BSD License",
-        "Operating System :: OS Independent",  # Assuming OpenSSL is available
+        "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setuptools.setup(
         "pyopenssl",
         "cryptography",
         "certifi",
+        "timeout-decorator",
     ],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setuptools.setup(
         "pyopenssl",
         "cryptography",
         "certifi",
-        "timeout-decorator",
     ],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,10 @@ setuptools.setup(
     py_modules=["aia"],
     include_package_data=True,
     python_requires=">=3.6",
+    install_requires=[
+        "cryptography",
+        "certifi",
+    ],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Environment :: Web Environment",

--- a/test/test.py
+++ b/test/test.py
@@ -602,7 +602,7 @@ def run_test(tmpdir):
     test_name = "aia_session.aia_chase with empty cafile"
     print(f"{test_name} ...")
     empty_file = f"{tmpdir}/empty-file"
-    open(empty_file, 'a').close() # create empty file
+    open(empty_file, "a").close()  # create empty file
     # create new session with empty cafile
     print("destroying aia_session")
     del aia_session
@@ -612,8 +612,10 @@ def run_test(tmpdir):
             cafile=empty_file,
         )
     except OpenSSL.SSL.Error as exc:
-        assert exc.args == ([('x509 certificate routines', '', 'no certificate or crl found')],)
-    aia_session = None # fix: del aia_session
+        assert exc.args == (
+            [("x509 certificate routines", "", "no certificate or crl found")],
+        )
+    aia_session = None  # fix: del aia_session
     print(f"{test_name} ok")
 
     print("-" * 80)
@@ -630,12 +632,14 @@ def run_test(tmpdir):
             cafile=missing_file,
         )
     except OpenSSL.SSL.Error as exc:
-        assert exc.args == ([
-            ('system library', '', ''),
-            ('BIO routines', '', 'no such file'),
-            ('x509 certificate routines', '', 'system lib')
-        ],)
-    aia_session = None # fix: del aia_session
+        assert exc.args == (
+            [
+                ("system library", "", ""),
+                ("BIO routines", "", "no such file"),
+                ("x509 certificate routines", "", "system lib"),
+            ],
+        )
+    aia_session = None  # fix: del aia_session
     print(f"{test_name} ok")
 
     print("-" * 80)
@@ -853,7 +857,7 @@ def run_test(tmpdir):
     print("aia tests done")
 
     keep_servers = False
-    #keep_servers = True
+    # keep_servers = True
 
     if keep_servers:
         # keep servers running for manual testing

--- a/test/test.py
+++ b/test/test.py
@@ -599,6 +599,47 @@ def run_test(tmpdir):
 
     print("-" * 80)
 
+    test_name = "aia_session.aia_chase with empty cafile"
+    print(f"{test_name} ...")
+    empty_file = f"{tmpdir}/empty-file"
+    open(empty_file, 'a').close() # create empty file
+    # create new session with empty cafile
+    print("destroying aia_session")
+    del aia_session
+    print("creating aia_session")
+    try:
+        aia_session = aia.AIASession(
+            cafile=empty_file,
+        )
+    except OpenSSL.SSL.Error as exc:
+        assert exc.args == ([('x509 certificate routines', '', 'no certificate or crl found')],)
+    aia_session = None # fix: del aia_session
+    print(f"{test_name} ok")
+
+    print("-" * 80)
+
+    test_name = "aia_session.aia_chase with missing cafile"
+    print(f"{test_name} ...")
+    # create new session with missing cafile
+    missing_file = "/var/empty/missing-file"
+    print("destroying aia_session")
+    del aia_session
+    print("creating aia_session")
+    try:
+        aia_session = aia.AIASession(
+            cafile=missing_file,
+        )
+    except OpenSSL.SSL.Error as exc:
+        assert exc.args == ([
+            ('system library', '', ''),
+            ('BIO routines', '', 'no such file'),
+            ('x509 certificate routines', '', 'system lib')
+        ],)
+    aia_session = None # fix: del aia_session
+    print(f"{test_name} ok")
+
+    print("-" * 80)
+
     # TODO test max_chain_depth=1
 
     # curl does not-yet support AIA

--- a/test/test.py
+++ b/test/test.py
@@ -599,38 +599,6 @@ def run_test(tmpdir):
 
     print("-" * 80)
 
-    test_name = "aia_session.aia_chase with cafile list"
-    print(f"{test_name} ...")
-    # create new session with cafile list
-    print("destroying aia_session")
-    del aia_session
-    print("creating aia_session")
-    # note: use same ca-bundle.crt for curl and aia
-    aia_session = aia.AIASession(
-        cafile=[
-            "/no/such/file",
-            "/",
-            cert0_path,
-        ],
-    )
-    url = https_server_url
-    url_parsed = urlsplit(url)
-    host = url_parsed.netloc  # note: netloc is host and port
-    # print(f"parsed host {repr(host)} from url {repr(url)}")
-    try:
-        verified_cert_chain, missing_certs = aia_session.aia_chase(
-            host,
-            timeout=1,
-            max_chain_depth=100,
-        )
-        # print("verified_cert_chain"); aia.print_chain(verified_cert_chain)
-        # print("missing_certs"); aia.print_chain(missing_certs)
-    except Exception:
-        raise
-    print(f"{test_name} ok")
-
-    print("-" * 80)
-
     # TODO test max_chain_depth=1
 
     # curl does not-yet support AIA

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import time
+import subprocess
+import tempfile
+import random
+from multiprocessing import Process
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+import ssl
+import datetime
+
+import OpenSSL
+print("imported OpenSSL module", OpenSSL)
+
+import cryptography
+print("imported cryptography module", cryptography)
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.hazmat.primitives.serialization import pkcs7
+
+sys.path.append(os.path.dirname(__file__) + "/..")
+import aia
+print("imported aia module", aia)
+
+# pyppeteer/util.py
+import gc
+import socket
+def get_free_port() -> int:
+    """Get free port."""
+    sock = socket.socket()
+    #sock.bind(('localhost', 0))
+    sock.bind(('127.0.0.1', 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    del sock
+    gc.collect()
+    return port
+
+
+
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+import datetime
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+
+def create_cert(name, issuer_cert=None, issuer_key=None, issuer_cert_url=None):
+
+    """
+    create a cryptography certificate and key.
+
+    note: not pyopenssl cert
+    """
+
+    print(f"creating cert {repr(name)}")
+
+    # https://cryptography.io/en/latest/x509/reference/#x-509-certificate-builder
+    # https://stackoverflow.com/questions/56285000/python-cryptography-create-a-certificate-signed-by-an-existing-ca-and-export
+
+    key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend()
+    )
+
+    subject_name = x509.Name([
+        x509.NameAttribute(NameOID.COUNTRY_NAME, u"US"),
+        x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"Texas"),
+        x509.NameAttribute(NameOID.LOCALITY_NAME, u"Austin"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"My Company"),
+        x509.NameAttribute(NameOID.COMMON_NAME, name),
+    ])
+
+    # root cert: issuer == subject
+    issuer_name = issuer_cert.subject if issuer_cert else subject_name
+
+    cert = x509.CertificateBuilder()
+
+    cert = cert.subject_name(subject_name)
+    cert = cert.issuer_name(issuer_name)
+    cert = cert.public_key(key.public_key())
+    cert = cert.serial_number(x509.random_serial_number())
+    cert = cert.not_valid_before(datetime.datetime.utcnow())
+    cert = cert.not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=3650))
+
+    if not issuer_cert:
+        cert = cert.add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+
+    if issuer_cert_url:
+        # add AIA extension
+        # https://github.com/pyca/cryptography/raw/main/tests/x509/test_x509.py
+        # aia = x509.AuthorityInformationAccess
+        cert = cert.add_extension(x509.AuthorityInformationAccess([
+            x509.AccessDescription(
+                x509.oid.AuthorityInformationAccessOID.CA_ISSUERS,
+                x509.UniformResourceIdentifier(issuer_cert_url),
+            ),
+        ]), critical=False)
+
+    cert = cert.sign(key, hashes.SHA256(), default_backend())
+
+    return cert, key
+
+
+
+def run_http_server(args):
+
+    host = args.get("host", "127.0.0.1")
+    port = args.get("port", 80)
+    ssl_cert_file = args.get("ssl_cert_file", None)
+    ssl_key_file = args.get("ssl_key_file", None)
+    root = args.get("root", "/tmp/www")
+    #tmpdir = args.get("tmpdir", "/tmp")
+
+    # https://stackoverflow.com/questions/22429648/ssl-in-python3-with-httpserver
+
+    # SimpleHTTPRequestHandler serves files from workdir
+    # this throws FileNotFoundError if root does not exist
+    os.chdir(root)
+
+    http_server = HTTPServer((host, port), SimpleHTTPRequestHandler)
+
+    if ssl_cert_file and ssl_key_file:
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ssl_context.check_hostname = False # If set to True, only the hostname that matches the certificate will be accepted
+        # https://docs.python.org/3/library/ssl.html
+        # The certfile string must be the path to a single file in PEM format containing the certificate
+        # as well as any number of CA certificates needed to establish the certificate’s authenticity.
+        # The keyfile string, if present, must point to a file containing the private key.
+        ssl_context.load_cert_chain(ssl_cert_file, ssl_key_file)
+        http_server.socket = ssl_context.wrap_socket(http_server.socket, server_side=True)
+
+    http_server.serve_forever()
+
+
+
+def run_test(tmpdir):
+
+    print(f"using tempdir {repr(tmpdir)}")
+
+    server_root = tmpdir + "/www"
+    os.mkdir(server_root)
+
+    # SSLContext.wrap_socket
+    # Wrap an existing Python socket
+
+    http_port = get_free_port()
+
+    # create certs
+    # TODO refactor ... create_cert_chain
+
+    # FIXME trust the root cert
+    # OpenSSL.crypto.X509StoreContextError: self-signed certificate in certificate chain
+
+    cert0, key0 = create_cert("root cert")
+    with open(f"{server_root}/cert0", "wb") as f:
+        # PEM format
+        f.write(cert0.public_bytes(encoding=serialization.Encoding.PEM))
+    url0 = f"http://127.0.0.1:{http_port}/cert0"
+
+    cert1, key1 = create_cert("branch cert 1", cert0, key0, url0)
+    with open(f"{server_root}/cert1", "wb") as f:
+        # DER = ASN1 format
+        f.write(cert1.public_bytes(encoding=serialization.Encoding.DER))
+    url1 = f"http://127.0.0.1:{http_port}/cert1"
+
+    # https://github.com/pyca/cryptography/raw/main/tests/hazmat/primitives/test_pkcs7.py
+    # encoding = serialization.Encoding.PEM
+    # encoding = serialization.Encoding.DER
+    # p7 = pkcs7.serialize_certificates(certs, encoding)
+    #f.write(cert2.public_bytes(encoding=serialization.Encoding.PEM))
+
+    """
+        f.write(pkcs7.serialize_certificates([cert2.to_cryptography()], Encoding.DER))
+                                              ^^^^^^^^^^^^^^^^^^^^^
+    AttributeError: 'cryptography.hazmat.bindings._rust.x509.Certificat' object has no attribute 'to_cryptography'
+
+    fix: cert2 already is a cryptography cert
+
+    nit: why "Certificat"? why not "Certificate" with a trailing "e"?
+    """
+
+    cert2, key2 = create_cert("branch cert 2", cert1, key1, url1)
+    with open(f"{server_root}/cert2", "wb") as f:
+        # PKCS7-DER format
+        #f.write(pkcs7.serialize_certificates([cert2.to_cryptography()], Encoding.DER))
+        f.write(pkcs7.serialize_certificates([cert2], Encoding.DER))
+    url2 = f"http://127.0.0.1:{http_port}/cert2"
+
+    cert3, key3 = create_cert("branch cert 3", cert2, key2, url2)
+    with open(f"{server_root}/cert3", "wb") as f:
+        # PKCS7-PEM format
+        #f.write(pkcs7.serialize_certificates([cert3.to_cryptography()], Encoding.PEM))
+        f.write(pkcs7.serialize_certificates([cert3], Encoding.PEM))
+    url3 = f"http://127.0.0.1:{http_port}/cert3"
+
+    # TODO test invalid url3 with invalid host or port
+
+    cert4, key4 = create_cert("leaf cert", cert3, key3, url3)
+
+    server_cert, server_key = cert4, key4
+
+    https_server_cert_file = tempfile.mktemp(suffix=".pem", prefix="cert-", dir=tmpdir)
+    with open(https_server_cert_file, "wb") as f:
+        #cert_pem = OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_PEM, server_cert) # pyopenssl
+        cert_pem = server_cert.public_bytes(encoding=serialization.Encoding.PEM) # cryptography
+        f.write(cert_pem)
+
+    https_server_key_file = tempfile.mktemp(suffix=".pem", prefix="key-", dir=tmpdir)
+    with open(https_server_key_file, "wb") as f:
+        #key_pem = OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, server_key) # pyopenssl
+        # cryptography
+        # https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/
+        key_pem = server_key.private_bytes(
+            encoding=serialization.Encoding.PEM, # PEM, DER
+            format=serialization.PrivateFormat.PKCS8, # TraditionalOpenSSL, OpenSSH, PKCS8
+            encryption_algorithm=serialization.NoEncryption(), # BestAvailableEncryption, NoEncryption
+        )
+        f.write(key_pem)
+
+    # start http server
+    schema = "http"
+    http_server_url = f"{schema}://127.0.0.1:{http_port}"
+    print(f"starting {schema} server on {http_server_url}")
+    http_server_args = dict(
+        host="127.0.0.1",
+        port=http_port,
+        ssl_cert_file=None,
+        ssl_key_file=None,
+        root=server_root,
+        #tmpdir=tmpdir,
+    )
+    http_server_process = Process(target=run_http_server, args=(http_server_args,))
+    http_server_process.start()
+
+    # start https server
+    schema = "https"
+    https_port = get_free_port()
+    https_server_url = f"{schema}://127.0.0.1:{https_port}"
+    print(f"starting {schema} server on {https_server_url}")
+    https_server_args = dict(
+        host="127.0.0.1",
+        port=https_port,
+        ssl_cert_file=https_server_cert_file,
+        ssl_key_file=https_server_key_file,
+        root=server_root,
+        #tmpdir=tmpdir,
+    )
+    https_server_process = Process(target=run_http_server, args=(https_server_args,))
+    https_server_process.start()
+
+    #print("todo run tests")
+    #time.sleep(60)
+
+    print("starting aia tests")
+
+    print("creating aia_session")
+    aia_session = aia.AIASession()
+
+    print("aia_session.cadata_from_url")
+    url = https_server_url
+    cadata = aia_session.cadata_from_url(url)
+    print(cadata)
+
+    print("done aia tests")
+
+    print(f"stopping {schema} server ...")
+    https_server_process.join()
+    print(f"stopping {schema} server done")
+
+
+
+def main():
+
+    # TODO check if dir exists
+    main_tempdir = f"/run/user/{os.getuid()}"
+
+    with (
+            tempfile.TemporaryDirectory(
+                prefix="python-aia-test",
+                dir=main_tempdir,
+                #ignore_cleanup_errors=False,
+            ) as tmpdir,
+        ):
+
+        return run_test(tmpdir)
+
+
+
+if __name__ == "__main__":
+
+    main()

--- a/test/test.py
+++ b/test/test.py
@@ -1,32 +1,32 @@
 #!/usr/bin/env python3
 
 import os
+import gc
+import ssl
 import sys
 import time
-import subprocess
-import tempfile
 import random
 import atexit
 import signal
 import shutil
+import socket
+import datetime
+import tempfile
+import subprocess
 from multiprocessing import Process
 from http.server import HTTPServer, SimpleHTTPRequestHandler
-import ssl
-import datetime
 from urllib.parse import urlsplit
 
 import OpenSSL
 
-print("imported OpenSSL module", OpenSSL)
-
 import cryptography
 
-print("imported cryptography module", cryptography)
-
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.hazmat.primitives.serialization import pkcs7
 
@@ -35,11 +35,8 @@ import aia
 
 print("imported aia module", aia)
 
+
 # pyppeteer/util.py
-import gc
-import socket
-
-
 def get_free_port() -> int:
     """Get free port."""
     sock = socket.socket()
@@ -50,23 +47,6 @@ def get_free_port() -> int:
     del sock
     gc.collect()
     return port
-
-
-from cryptography import x509
-from cryptography.x509.oid import NameOID
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-
-import datetime
-
-from cryptography import x509
-from cryptography.x509.oid import NameOID
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 
 
 def create_cert(

--- a/test/test.py
+++ b/test/test.py
@@ -599,6 +599,38 @@ def run_test(tmpdir):
 
     print("-" * 80)
 
+    test_name = "aia_session.aia_chase with cafile list"
+    print(f"{test_name} ...")
+    # create new session with cafile list
+    print("destroying aia_session")
+    del aia_session
+    print("creating aia_session")
+    # note: use same ca-bundle.crt for curl and aia
+    aia_session = aia.AIASession(
+        cafile=[
+            "/no/such/file",
+            "/",
+            cert0_path,
+        ],
+    )
+    url = https_server_url
+    url_parsed = urlsplit(url)
+    host = url_parsed.netloc  # note: netloc is host and port
+    # print(f"parsed host {repr(host)} from url {repr(url)}")
+    try:
+        verified_cert_chain, missing_certs = aia_session.aia_chase(
+            host,
+            timeout=1,
+            max_chain_depth=100,
+        )
+        # print("verified_cert_chain"); aia.print_chain(verified_cert_chain)
+        # print("missing_certs"); aia.print_chain(missing_certs)
+    except Exception:
+        raise
+    print(f"{test_name} ok")
+
+    print("-" * 80)
+
     # TODO test max_chain_depth=1
 
     # curl does not-yet support AIA


### PR DESCRIPTION
make aia 30x faster

```
$ time python -c "import aia; aia_session = aia.AIASession(); url = 'https://www788.ucdn.to:183/'; cadata = aia_session.cadata_from_url(url); # print(cadata)"

real    0m2.561s
user    0m1.183s
sys     0m0.154s
```

before

```
$ time python -c "import aia; aia_session = aia.AIASession(); url = 'https://www788.ucdn.to:183/'; cadata = aia_session.cadata_from_url(url); # print(cadata)"

real    1m7.455s
user    0m56.139s
sys     0m6.182s
```

downstream PR: https://github.com/pyload/pyload/pull/4478

### cache cadata by host regex

save memory and time

in this example, `target_name` is `*.ucdn.to`
so cadata is computed only for the first request with `www788.ucdn.to`
and the cached value is used for `www123.UCDN.to`

```
$ python -c "import aia; import time; aia_session = aia.AIASession(); url = 'https://www788.ucdn.to:183/'; t1 = time.time(); cadata = aia_session.cadata_from_url(url); print(time.time() - t1); url = 'https://www123.UCDN.to:183/';  t1 = time.time(); cadata = aia_session.cadata_from_url(url); print(time.time() - t1);"
0.7428784370422363
0.00014781951904296875
```

### custom caching

the new method `cadata_and_host_regex_from_host`
is useful to implement custom caching
without having to re-parse the leaf cert for the host regex

for example, pycurl loads cacert from a file
so the certs for `*.ucdn.to` can be stored in `cache/certs/_.ucdn.to.crt`
and `host_regex` can be used to select the cert file

### caching fetched certs

allow the user to cache fetched certs to disk

so for example, when fetching the cert from
`http://secure.globalsign.com/cacert/gsgccr6alphasslca2023.crt`
then store the cert in
`/tmp/aia-certs/secure.globalsign.com/cacert/gsgccr6alphasslca2023.crt`

```py
aia_session = aia.AIASession(cert_cache='/tmp/aia-certs')
```


this is useful to address the [privacy concerns with AIA](https://akamath32.medium.com/certificate-authority-information-access-aia-7bc56f7257fc)

> AIA by itself isn’t posing any risk to the security aspects of TLS, but there might be privacy implications with the hosting service of the intermediate certificates getting requests from the client which it otherwise would not have.

### todo: fetch all certs from server

currently we fetch only the first cert = leaf cert
`ss.getpeercert(True)`

to fetch all certs:
see also [Getting certificate chain with Python 3.3 SSL module](https://stackoverflow.com/a/67212703/10440128)

for example, `www.google.com:443` returns 3 certs

```
0 subject: <X509Name object '/CN=www.google.com'>
  issuer: <X509Name object '/C=US/O=Google Trust Services LLC/CN=GTS CA 1C3'>)
  fingerprint: b'B3:22:59:5F:56:F1:86:51:9F:ED:50:13:3E:AA:BD:6B:DD:16:3B:04'
1 subject: <X509Name object '/C=US/O=Google Trust Services LLC/CN=GTS CA 1C3'>
  issuer: <X509Name object '/C=US/O=Google Trust Services LLC/CN=GTS Root R1'>)
  fingerprint: b'1E:7E:F6:47:CB:A1:50:28:1C:60:89:72:57:10:28:78:C4:BD:8C:DC'
2 subject: <X509Name object '/C=US/O=Google Trust Services LLC/CN=GTS Root R1'>
  issuer: <X509Name object '/C=BE/O=GlobalSign nv-sa/OU=Root CA/CN=GlobalSign Root CA'>)
  fingerprint: b'08:74:54:87:E8:91:C1:9E:30:78:C1:F2:A0:7E:45:29:50:EF:36:F6'
```

cert 2 is signed by `GlobalSign Root CA` which is in the default `ca-bundle.crt`
so the full chain is valid, and there is no need to fetch certs

to compare: `www788.ucdn.to:183` returns 2 certs
but for cert 0, the issuer `GlobalSign GCC R6 AlphaSSL CA` is missing
so this cert must be fetched from
`http://secure.globalsign.com/cacert/gsgccr6alphasslca2023.crt`
... which is issued by `CN = GlobalSign` which is in the default `ca-bundle.crt`

```
0 subject: <X509Name object '/CN=*.ucdn.to'>
  issuer: <X509Name object '/C=BE/O=GlobalSign nv-sa/CN=GlobalSign GCC R6 AlphaSSL CA 2023'>)
  fingerprint: b'F0:65:DF:D9:14:1B:89:95:5F:85:B5:B3:39:5C:ED:CA:7E:F5:AC:2C'
1 subject: <X509Name object '/C=BE/O=GlobalSign nv-sa/OU=Root CA/CN=GlobalSign Root CA'>
  issuer: <X509Name object '/C=BE/O=GlobalSign nv-sa/OU=Root CA/CN=GlobalSign Root CA'>)
  fingerprint: b'B1:BC:96:8B:D4:F4:9D:62:2A:A8:9A:81:F2:15:01:52:A4:1D:82:9C'
```