### PR TITLE
[FIX] Add PKCS#7 certificates support

### DIFF
--- a/aia.py
+++ b/aia.py
@@ -8,7 +8,6 @@ import subprocess
 from tempfile import NamedTemporaryFile
 from urllib.request import urlopen, Request
 from urllib.parse import urlsplit
-import warnings
 
 
 __version__ = "0.2.0"
@@ -150,10 +149,8 @@ class AIASession:
 
     def __init__(self, user_agent=DEFAULT_USER_AGENT):
         self.user_agent = user_agent
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            self._context = ssl.SSLContext()  # TLS (don't check broken chain)
-            self._context.load_default_certs()
+        self._context = ssl.SSLContext()  # TLS (don't check broken chain)
+        self._context.load_default_certs()
 
         # Trusted certificates whitelist in dict format like:
         # {"RFC4514 string": b"DER certificate contents"}


### PR DESCRIPTION
Hello!

I noticed some certificate providers were providing their certificates as [PKCS#7](https://en.wikipedia.org/wiki/PKCS_7) files (which is usually a set of PEM certificates). This causes an issue on `openssl_get_cert_info` being unable to extract issuer and subject information.

## Reproducing

One such example of root certificate is *Sectigo Public Server Authentication Root R46*, which I found [https://api.publiccontractsscotland.gov.uk](https://api.publiccontractsscotland.gov.uk) to be certified under.

With the following code, you get a `KeyError` in `openssl_get_cert_info`:
```python
from aia import AIASession

aia_session = AIASession()
cadata = aia_session.cadata_from_url("https://api.publiccontractsscotland.gov.uk")
```

## Proposed solution

I used two functions both using `openssl` command.
1. `is_pkcs7` one to determine if the certificate is in PKCS#7 format by running `openssl pkcs7 -inform DER -print_certs -noout`.
2. `pkcs7_to_der` that runs two commands:
    1. `openssl pkcs7 -inform DER -print_certs` to output the certificates as PEM,
    2. `openssl x509 -inform DER -outform DER` to convert the PEM into DER to remain consistent with the remaining logic that handles DER.
    
Let me know if you have any feedback I could incorporate!
    
    
  